### PR TITLE
Fix/use local temp generate folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vscode
 lib
 .yarn
+.tmp-generate

--- a/src/internal/reference/generate.js
+++ b/src/internal/reference/generate.js
@@ -8,6 +8,7 @@ import packageJson from '../../../package.json' with { type: 'json' };
 import { FILE_BANNER, processApiSource } from './ast-utilities.js';
 import blacklistConfig from './blacklist.json' with { type: 'json' };
 import filesConfig from './files.json' with { type: 'json' };
+import { cwd } from 'process';
 
 const __dirname = import.meta.dirname;
 
@@ -27,13 +28,14 @@ const fileGroupAssociations = {
 };
 
 /**
- * Creates a temporary directory for processing
+ * Creates a temporary directory within the project for processing.
+ * This avoids cross-device link issues.
  *
- * TECH DEBT: this implementation causes a file access issue in new versions of Ubuntu
  * @returns {Promise<string>} The path to the temporary directory
  */
 async function makeTempDir() {
-    const tempOutputDir = join(tempDir, `${packageJson.name.split('/').slice(-1)[0]}-${uuid()}`);
+    const projectBaseTempDir = join(cwd(), '.tmp-generate');
+    const tempOutputDir = join(projectBaseTempDir, `${packageJson.name.split('/').slice(-1)[0]}-${uuid()}`);
     await mkdir(tempOutputDir, { recursive: true });
     return tempOutputDir;
 }

--- a/src/internal/reference/generated/orders.v3.ts
+++ b/src/internal/reference/generated/orders.v3.ts
@@ -1225,9 +1225,7 @@ export interface components {
          * RefundQuote_Post
          * @description Request body for refund quotes.
          */
-        readonly RefundQuote_Post: {
-            readonly items: readonly components["schemas"]["ItemsRefund"][];
-        };
+        readonly RefundQuote_Post: components["schemas"]["RefundQuote_ItemsRefund"] | components["schemas"]["RefundQuote_TaxAdjustmentAmount"];
         /** RefundQuote_Full */
         readonly RefundQuote_Full: {
             /** @description ID of the order to be refunded. */
@@ -1304,9 +1302,16 @@ export interface components {
          * RefundRequest_Post
          * @description Request body for refund requests.
          */
-        readonly RefundRequest_Post: {
+        readonly RefundRequest_Post: components["schemas"]["RefundRequest_Post_Items"] | components["schemas"]["RefundRequest_Post_TaxAdjustmentAmount"];
+        /** Items Refund */
+        readonly RefundRequest_Post_Items: {
             readonly items: readonly components["schemas"]["ItemsRefund"][];
             readonly payments: readonly components["schemas"]["PaymentRequest"][];
+            readonly merchant_calculated_override?: components["schemas"]["MerchantOverride"];
+        };
+        /** Tax Adjustment Refund */
+        readonly RefundRequest_Post_TaxAdjustmentAmount: {
+            readonly tax_adjustment_amount: components["schemas"]["TaxAdjustmentAmount"];
             readonly merchant_calculated_override?: components["schemas"]["MerchantOverride"];
         };
         readonly RefundID_Get: {
@@ -1364,6 +1369,7 @@ export interface components {
                      *      */
                     readonly declined_message?: string;
                 }[];
+                /** @description Array of items refunded. In cases when `tax_refund_adjustment` was used to create the refund, this array will be empty. */
                 readonly items?: readonly {
                     /**
                      * @description Type of item that was refunded.
@@ -1568,6 +1574,23 @@ export interface components {
             /** @description Total tax amount refunded back to the shopper. Use 0 value if there is no tax liability change for the refund or tax does not need to be recorded on the refund and would be handled externally. */
             readonly total_tax: number;
         };
+        /**
+         * Tax Adjustment Amount
+         * Format: float
+         * @description Amount to be used when tax may have been overcharged for an order, such as when the value for a partial refund is overridden. This amount should be equal to the calculated overcharged value, or should be used with `merchant_calculated_override` to override the value. If not, this will result in a `422` error.
+         * @example 1.99
+         */
+        readonly TaxAdjustmentAmount: number;
+        /** Items Refund */
+        readonly RefundQuote_ItemsRefund: {
+            readonly items: readonly components["schemas"]["ItemsRefund"][];
+            readonly merchant_calculated_override?: components["schemas"]["MerchantOverride"];
+        };
+        /** Tax Adjustment Refund */
+        readonly RefundQuote_TaxAdjustmentAmount: {
+            readonly tax_adjustment_amount: components["schemas"]["TaxAdjustmentAmount"];
+            readonly merchant_calculated_override?: components["schemas"]["MerchantOverride"];
+        };
         /** Refund */
         readonly Refund: {
             /** @description Refund resource ID. */
@@ -1588,7 +1611,7 @@ export interface components {
             readonly total_tax?: number;
             /** @description Whether refund amount and tax are provided explicitly by merchant override. */
             readonly uses_merchant_override_values?: boolean;
-            /** @description Array of items refunded. */
+            /** @description Array of items refunded. In cases when `tax_refund_adjustment` was used to create the refund, this array will be empty. */
             readonly items?: readonly components["schemas"]["RefundItem"][];
             /** @description An array of refund payments made to payment providers. */
             readonly payments?: readonly components["schemas"]["RefundPayment"][];


### PR DESCRIPTION
---

**Description of the proposed changes**
When regenerating the source type files, write temporary output to a local directory instead of the system temporary directory. On newer Ubuntu versions attempting to write to the temporary folder causes a `cross-device link not permitted` error e.g.

`Failed to generate TypeScript types: Error: EXDEV: cross-device link not permitted, rename '/tmp/bigcommerce-api-4bd94e0e-cf17-40e1-be22-a26a8d850f6b' `


I've also rebuilt the type files, so there's a change to the Orders types reflecting updates to the BigCommerce documentation

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
