### PR TITLE
Add script to parse changes from one version to the next and record in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ BigCommerce have changed their published schemas substantially since the last ti
 
 This project strictly follows [Semantic Versioning](http://semver.org/).
 
+New versions may include changes pulled from the BigCommerce source schemas. Look in [docs/changelog](./docs//changelog/) for any resulting changes to interfaces.
+
 ## Support
 
 If you have a problem with this library, please file an [issue](https://github.com/aligent/bigcommerce-api/issues/new) here on GitHub.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint .",
     "build:file-list": "node src/internal/reference/list-files",
     "build:reference-types": "node src/internal/reference/generate",
-    "build:clean": "rimraf dist && npm run build:file-list && npm run build:reference-types && npm run build",
+    "build:summarize-changes": "node scripts/summarize-changes",
+    "build:clean": "rimraf dist && npm run build:file-list && npm run build:reference-types && npm run build:summarize-changes",
     "build": "tshy"
   },
   "exports": {
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@aligent/ts-code-standards": "^4.0.0",
     "@types/node": "^22.13.14",
+    "diff": "^8.0.0-beta",
     "eslint": "^9.25.1",
     "openapi-typescript": "^7.6.1",
     "prettier": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "openapi-typescript": "^7.6.1",
     "prettier": "^3.5.3",
     "rimraf": "^6.0.1",
+    "simple-git": "^3.27.0",
     "temp-dir": "^3.0.0",
     "ts-morph": "^25.0.1",
     "tsd": "^0.32.0",

--- a/scripts/summarize-changes.js
+++ b/scripts/summarize-changes.js
@@ -1,0 +1,324 @@
+// TECH DEBT: This is a naive approach that uses regex to remove JSDocs and find parents properties.
+// It can probably be improved by leaning more on ts-morph to parse the AST.
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+import { Project } from 'ts-morph';
+import * as Diff from 'diff';
+
+const packageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
+const version = packageJson.version;
+
+const config = {
+    version,
+    baseRef: 'HEAD~1',
+    targetDir: 'src/internal/reference/generated',
+    outputFile: `docs/changelog/${version}.md`,
+}
+
+/**
+ * Gets the content of a file at a specific Git reference.
+ * @param {string} gitRef
+ * @param {string} filePath - Path relative to repo root
+ * @returns {string | null}
+ */
+function getFileContentAtRef(gitRef, filePath) {
+    try {
+        const contentBuffer = execSync(`git show ${gitRef}:${filePath}`, { encoding: 'buffer', stdio: 'pipe' });
+        return contentBuffer.toString('utf-8');
+    } catch (error) {
+        // Handle case where file didn't exist at that ref (e.g., new file)
+        // Check stderr for common "does not exist" messages
+        const stderr = error.stderr ? error.stderr.toString() : '';
+        if (stderr.includes('exists on disk, but not in') || stderr.includes('does not exist')) {
+            return null;
+        }
+        console.warn(`Warning: Could not get content of ${filePath} at ${gitRef}. Error: ${error} Stderr: ${stderr}`);
+        return null;
+    }
+}
+
+/**
+ * Removes all JSDoc block comments  from source code.
+ * @param {string} sourceCode The input source code.
+ * @returns {string} Source code with JSDoc blocks removed.
+ */
+function stripAllJsDocs(sourceCode) {
+    if (!sourceCode) return '';
+    // Regex to find JSDoc blocks: starts with /**, ends with */, allows any characters including newlines in between (*?).
+    // The 'g' flag ensures all occurrences are replaced.
+    const jsDocRegex = /\/\*\*[\s\S]*?\*\/\s*/g;
+    return sourceCode.replace(jsDocRegex, '');
+}
+
+/**
+ * Extracts exported interface details from TypeScript source code.
+ * Assumes JSDoc has already been stripped from the input sourceCode.
+ * @param {Project} project - The ts-morph project instance.
+ * @param {string} sourceCode - The TypeScript source code content (JSDoc removed).
+ * @param {string} virtualFilePath - A unique virtual path for ts-morph.
+ * @returns {Map<string, {name: string, members: Map<string, {name: string, signature: string}>}>}
+ */
+function extractInterfaces(project, sourceCode, virtualFilePath) {
+    const interfaces = new Map();
+    const sourceFile = project.createSourceFile(virtualFilePath, sourceCode, {
+        overwrite: true,
+    });
+
+    sourceFile.getInterfaces().forEach(interfaceDeclaration => {
+        // Only extract exported interfaces as they represent the public API
+        if (interfaceDeclaration.isExported()) {
+            const interfaceName = interfaceDeclaration.getName();
+            const membersMap = new Map();
+            interfaceDeclaration.getMembers().forEach(member => {
+                const memberName = member.getName();
+                 // Get text directly from the node in the JSDoc-stripped AST
+                const signature = member.getText().trim();
+
+                if (memberName && signature) {
+                    membersMap.set(memberName, { name: memberName, signature: signature });
+                }
+            });
+            interfaces.set(interfaceName, { name: interfaceName, members: membersMap });
+        }
+    });
+    return interfaces;
+}
+
+/**
+ * Formats the diff output for markdown and tries to infer the nested context name.
+ * @param {Diff.Change[]} lineDiffs - Array of change objects from diffLines.
+ * @returns {{diffBlock: string[], contextName: string | null}} - Formatted diff lines and the inferred context name (e.g., 'CategoryNode').
+ */
+function formatLineDiffAndInferContext(lineDiffs) {
+    const outputLines = [];
+    let lastPotentialContextName = null;
+    let contextNameForChange = null;
+    let hasVisibleChanges = false;
+    // Regex to capture a potential property name before an opening brace, possibly readonly.
+    // Captures the identifier (\w+). Increased robustness for whitespace.
+    const contextNameRegex = /^\s*(?:readonly\s+)?(\w+)\s*:\s*\{/;
+
+    // First pass: identify actual changes and collect lines
+    const changeParts = lineDiffs.filter(part => part.added || part.removed);
+    if (changeParts.length === 0) {
+         // If ignoreWhitespace=true caused no +/- lines, return empty
+         return { diffBlock: [], contextName: null };
+    }
+
+    outputLines.push('    ```diff');
+    let changeBlockActive = false;
+
+    lineDiffs.forEach(part => {
+        const lines = part.value.split('\n');
+
+        if (!part.added && !part.removed) {
+             // Look for context in lines preceding a change block
+            lines.forEach(line => {
+                const match = line.match(contextNameRegex);
+                if (match && !changeBlockActive) { // Only update context if we are not inside a change block
+                    lastPotentialContextName = match[1];
+                }
+            });
+            changeBlockActive = false; // Reset flag when entering context block
+        } else {
+            // This part has additions or removals
+            hasVisibleChanges = true;
+            changeBlockActive = true; // Set flag when inside a change block
+            if (contextNameForChange === null && lastPotentialContextName !== null) {
+                 // Capture the last known context name *before* the first change line
+                 contextNameForChange = lastPotentialContextName;
+            }
+
+            const prefix = part.added ? '+ ' : '- ';
+            lines.forEach((line, idx) => {
+                 // Avoid adding trailing newline as a separate diff line if it exists
+                if (idx === lines.length - 1 && line === '') return;
+                 outputLines.push(`    ${prefix}${line}`);
+            });
+        }
+    });
+
+    outputLines.push('    ```');
+
+    // Ensure we only return a diff block if there were actual visible changes
+    return {
+         diffBlock: hasVisibleChanges ? outputLines : [],
+         contextName: contextNameForChange // Return the context identified before the first +/- line
+     };
+}
+
+/**
+ * Compares two sets of interface definitions and returns a summary string array.
+ * Operates on signatures assumed to be JSDoc-free due to pre-processing.
+ * @param {Map<string, {name: string, members: Map<string, {name: string, signature: string}>}>} oldInterfaces
+ * @param {Map<string, {name: string, members: Map<string, {name: string, signature: string}>}>} newInterfaces
+ * @returns {string[]}
+ */
+function compareInterfaces(oldInterfaces, newInterfaces) {
+    const changes = [];
+    const allNames = new Set([...oldInterfaces.keys(), ...newInterfaces.keys()]);
+
+    for (const name of allNames) {
+        const oldI = oldInterfaces.get(name);
+        const newI = newInterfaces.get(name);
+
+        if (!oldI && newI) {
+            // Avoid adding empty interfaces (e.g., if only JSDoc was removed)
+            if (newI.members.size > 0) {
+                 changes.push(`- **Added Interface:** \`${name}\``);
+            }
+        } else if (oldI && !newI) {
+             // Avoid adding empty interfaces (e.g., if only JSDoc was removed)
+             if (oldI.members.size > 0) {
+                changes.push(`- **Removed Interface:** \`${name}\``);
+             }
+        } else if (oldI && newI) {
+            const memberChanges = [];
+            const allMemberNames = new Set([...oldI.members.keys(), ...newI.members.keys()]);
+
+            for (const memberName of allMemberNames) {
+                const oldM = oldI.members.get(memberName);
+                const newM = newI.members.get(memberName);
+
+                 if (!oldM && newM) {
+                    memberChanges.push(`  - Added member \`${newM.signature}\``);
+                } else if (oldM && !newM) {
+                    memberChanges.push(`  - Removed member \`${oldM.name}\``);
+                }
+                // Compare JSDoc-free signatures
+                else if (oldM && newM && oldM.signature !== newM.signature) {
+                    const lineDiffs = Diff.diffLines(oldM.signature, newM.signature, {
+                        newlineIsToken: true,
+                        ignoreWhitespace: true, // Ignore whitespace-only changes
+                    });
+
+                     // Get formatted diff and inferred context
+                     const { diffBlock, contextName } = formatLineDiffAndInferContext(lineDiffs);
+
+                    // Only report if there are actual diff lines to show
+                    if (diffBlock.length > 0) {
+                        // Construct label with context if found
+                         const label = `  - Modified member \`${memberName}${contextName ? '.' + contextName : ''}\`:`;
+                         memberChanges.push(label);
+                         memberChanges.push(...diffBlock);
+                    }
+                }
+            }
+
+            if (memberChanges.length > 0) {
+                changes.push(`- **Modified Interface:** \`${name}\``);
+                changes.push(...memberChanges);
+            }
+        }
+    }
+    return changes;
+}
+
+/**
+ * Gets a list of TypeScript/TSX files that have changed (staged or unstaged)
+ * compared to BASE_REF within the target directory.
+ * @returns {string[]} List of file paths relative to the repo root.
+ */
+function getChangedTsFiles() {
+    const statusCmd = `git status --porcelain=v1 --untracked-files=all -- "${config.targetDir}"`;
+
+    let changedOrNewFiles = new Set();
+
+     try {
+        const statusOutput = execSync(statusCmd, { encoding: 'utf-8' });
+        statusOutput.split('\n').filter(Boolean).forEach(line => {
+            const status = line.substring(0, 2);
+            const filePath = line.substring(3).trim();
+            const cleanedPath = filePath.startsWith('"') && filePath.endsWith('"')
+                ? filePath.substring(1, filePath.length - 1)
+                : filePath;
+
+            if ((cleanedPath.endsWith('.ts') || cleanedPath.endsWith('.tsx')) && cleanedPath.startsWith(config.targetDir)) {
+                 changedOrNewFiles.add(cleanedPath);
+            } else if (status.startsWith('R')) { // Handle renames R source -> dest
+                const paths = cleanedPath.split(' -> ');
+                const sourcePath = paths[0];
+                const destPath = paths[1];
+                 if (((sourcePath.endsWith('.ts') || sourcePath.endsWith('.tsx')) && sourcePath.startsWith(config.targetDir))) {
+                    changedOrNewFiles.add(sourcePath);
+                 }
+                 if (((destPath.endsWith('.ts') || destPath.endsWith('.tsx')) && destPath.startsWith(config.targetDir))) {
+                    changedOrNewFiles.add(destPath);
+                 }
+            }
+        });
+    } catch (e) {
+        console.error(`Error running git status: ${e}`);
+        return [];
+    }
+    return Array.from(changedOrNewFiles);
+}
+
+
+// --- Main Execution ---
+async function main() {
+    console.log(`Comparing interface changes (pre-stripping JSDoc) between ${config.baseRef} and working tree in ${config.targetDir}...`);
+    let summary = `# Interface Change Summary: ${config.version}\n\n`;
+    const projectOld = new Project({ useInMemoryFileSystem: true });
+    const projectNew = new Project({ useInMemoryFileSystem: true });
+
+    try {
+        const changedFiles = getChangedTsFiles();
+
+        if (changedFiles.length === 0) {
+            summary += `No interface changes in ${config.targetDir}.\n`;
+            console.log(`No interface changes in ${config.targetDir}.`);
+            writeFileSync(config.outputFile, summary);
+            return;
+        }
+
+        console.log(`Found changed/new files in ${config.targetDir}:\n${changedFiles.join('\n')}`);
+
+        for (const filePath of changedFiles) {
+            const absoluteFilePath = resolve(filePath);
+            console.log(`Processing ${filePath}...`);
+
+            // Pre-process old and new content to remove JSDocs
+            const rawOldContent = getFileContentAtRef(config.baseRef, filePath);
+            const oldContentStripped = stripAllJsDocs(rawOldContent);
+
+            let rawNewContent = null;
+            if (existsSync(absoluteFilePath)) {
+                 try {
+                    rawNewContent = readFileSync(absoluteFilePath, 'utf-8');
+                 } catch (readError) {
+                     console.warn(`Warning: Could not read file ${filePath} from disk. Error: ${readError}`);
+                 }
+            } else {
+                console.log(`  File ${filePath} does not exist in working directory (likely deleted or renamed away).`);
+            }
+            const newContentStripped = stripAllJsDocs(rawNewContent);
+
+
+            // Parse and compare interfaces
+            const oldInterfaces = oldContentStripped
+                ? extractInterfaces(projectOld, oldContentStripped, `${filePath}.old.virtual.ts`)
+                : new Map();
+            const newInterfaces = newContentStripped
+                ? extractInterfaces(projectNew, newContentStripped, `${filePath}.new.virtual.ts`)
+                : new Map();
+
+            const fileChanges = compareInterfaces(oldInterfaces, newInterfaces);
+
+            if (fileChanges.length > 0) {
+                const displayPath = filePath.replace(new RegExp(`^${config.targetDir}/`), '');
+                summary += `## \`${displayPath}\`\n\n`;
+                summary += fileChanges.join('\n') + '\n\n';
+            }
+        }
+
+        writeFileSync(config.outputFile, summary);
+        console.log(`Summary written to ${config.outputFile}`);
+    } catch (error) {
+        console.error('Error generating interface change summary:', error);
+        process.exit(1);
+    }
+}
+
+main();

--- a/scripts/summarize-changes.js
+++ b/scripts/summarize-changes.js
@@ -18,11 +18,11 @@
  */
 // TECH DEBT: This is a naive approach that uses regex to remove JSDocs and find parents properties.
 // It can probably be improved by leaning more on ts-morph to parse the AST.
-import { execSync } from 'child_process';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { diffLines } from 'diff';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
+import { GitError, simpleGit } from 'simple-git';
 import { Project, SyntaxKind } from 'ts-morph';
-import * as Diff from 'diff';
 
 const packageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
 
@@ -30,8 +30,8 @@ const config = {
     version: packageJson.version,
     baseRef: 'HEAD~1',
     targetDir: 'src/internal/reference/generated',
-    outputDir: `docs/changelog`
-}
+    outputDir: `docs/changelog`,
+};
 
 function formatOutputFileName(config) {
     return `${config.outputDir}/${config.version}.md`;
@@ -39,24 +39,30 @@ function formatOutputFileName(config) {
 
 /**
  * Gets the content of a file at a specific Git reference.
- * @param {string} gitRef
+ *
+ * @param {object} git - The simple-git instance.
+ * @param {string} gitRef - The git reference to check.
  * @param {string} filePath - Path relative to repo root
- * @returns {string} The file content or an empty string if the file doesn't exist at that ref.
+ * @returns {Promise<string>} The file content or an empty string if the file doesn't exist at that ref.
  */
-function getFileContentAtRef(gitRef, filePath) {
-    try {
-        const contentBuffer = execSync(`git show ${gitRef}:${filePath}`, { encoding: 'buffer', stdio: 'pipe' });
-        return contentBuffer.toString('utf-8');
-    } catch (error) {
-        // Handle case where file didn't exist at that ref (e.g., new file)
-        // Check stderr for common "does not exist" messages
-        const stderr = error.stderr ? error.stderr.toString() : '';
-        if (stderr.includes('exists on disk, but not in') || stderr.includes('does not exist')) {
+async function getFileContentAtRef(git, gitRef, filePath) {
+    return git.show(`${gitRef}:${filePath}`).catch(error => {
+        // If the error is that the file didn't exist for the given ref, return an empty string.
+        // This means the file is new and we're happy to continue as though it's an empty file.
+        if (
+            error instanceof GitError &&
+            [
+                `exists on disk, but not in '${gitRef}'`,
+                `does not exist in '${gitRef}'`,
+                `Path '${filePath}' does not exist in '${gitRef}'`,
+            ].some(error.stderr.includes)
+        ) {
             return '';
         }
-        console.warn(`Warning: Could not get content of ${filePath} at ${gitRef}. Error: ${error} Stderr: ${stderr}`);
-        return '';
-    }
+
+        // Some other error, rethrow it.
+        throw error;
+    });
 }
 
 /**
@@ -73,7 +79,9 @@ function getFileContentInWorkingDirectory(absoluteFilePath, filePath) {
             console.warn(`Warning: Could not read file ${filePath} from disk. Error: ${readError}`);
         }
     } else {
-        console.log(`File ${filePath} does not exist in working directory (likely deleted or renamed away).`);
+        console.log(
+            `File ${filePath} does not exist in working directory (likely deleted or renamed away).`
+        );
     }
     return '';
 }
@@ -108,7 +116,7 @@ function extractInterfaces(project, sourceCode, virtualFilePath) {
             const membersMap = new Map();
             interfaceDeclaration.getMembers().forEach(member => {
                 const memberName = member.getName();
-                 // Get text directly from the node in the JSDoc-stripped AST
+                // Get text directly from the node in the JSDoc-stripped AST
                 const signature = member.getText().trim();
 
                 if (memberName && signature) {
@@ -124,7 +132,7 @@ function extractInterfaces(project, sourceCode, virtualFilePath) {
 
 /**
  * Formats the diff output for markdown and tries to infer the nested context name.
- * @param {Diff.Change[]} lineDiffs - Array of change objects from diffLines.
+ * @param {object[]} lineDiffs - Array of change objects from diffLines.
  * @returns {{diffBlock: string[], contextName: string | null}} - Formatted diff lines and the inferred context name (e.g., 'CategoryNode').
  */
 function formatLineDiffAndInferContext(lineDiffs) {
@@ -139,7 +147,7 @@ function formatLineDiffAndInferContext(lineDiffs) {
     // Check if we have any actual changes to report, return early if not
     const changeParts = lineDiffs.filter(part => part.added || part.removed);
     if (!changeParts.length) {
-         return { diffBlock: [], contextName: null };
+        return { diffBlock: [], contextName: null };
     }
 
     // Start writing the diff block - e.g.
@@ -156,10 +164,11 @@ function formatLineDiffAndInferContext(lineDiffs) {
         // The logic here is a bit complex - the purpose is to find the 'context' for a change,
         // which is usually the name of the interface or property that the changed member belongs to.
         if (!part.added && !part.removed) {
-             // Look for context in lines preceding a change block
+            // Look for context in lines preceding a change block
             lines.forEach(line => {
                 const match = line.match(contextNameRegex);
-                if (match && !changeBlockActive) { // Only update context if we are not inside a change block
+                if (match && !changeBlockActive) {
+                    // Only update context if we are not inside a change block
                     lastPotentialContextName = match[1];
                 }
             });
@@ -169,15 +178,15 @@ function formatLineDiffAndInferContext(lineDiffs) {
             hasVisibleChanges = true;
             changeBlockActive = true; // Set flag when inside a change block
             if (contextNameForChange === null && lastPotentialContextName !== null) {
-                 // Capture the last known context name *before* the first change line
-                 contextNameForChange = lastPotentialContextName;
+                // Capture the last known context name *before* the first change line
+                contextNameForChange = lastPotentialContextName;
             }
 
             const prefix = part.added ? '+ ' : '- ';
             lines.forEach((line, idx) => {
-                 // Avoid adding trailing newline as a separate diff line if it exists
+                // Avoid adding trailing newline as a separate diff line if it exists
                 if (idx === lines.length - 1 && line === '') return;
-                 outputLines.push(`    ${prefix}${line}`);
+                outputLines.push(`    ${prefix}${line}`);
             });
         }
     });
@@ -187,9 +196,9 @@ function formatLineDiffAndInferContext(lineDiffs) {
 
     // Ensure we only return a diff block if there were actual visible changes
     return {
-         diffBlock: hasVisibleChanges ? outputLines : [],
-         contextName: contextNameForChange // Return the context identified before the first +/- line
-     };
+        diffBlock: hasVisibleChanges ? outputLines : [],
+        contextName: contextNameForChange, // Return the context identified before the first +/- line
+    };
 }
 
 /**
@@ -210,14 +219,14 @@ function compareInterfaces(oldInterfaces, newInterfaces) {
         // In the unlikely event that an entire interface was added or removed,
         // Handle it here.
         if (!oldI) {
-                 changes.push(`- **Added Interface:** \`${name}\``);
+            changes.push(`- **Added Interface:** \`${name}\``);
             continue;
-            }
+        }
 
         if (!newI) {
-                changes.push(`- **Removed Interface:** \`${name}\``);
+            changes.push(`- **Removed Interface:** \`${name}\``);
             continue;
-             }
+        }
 
         if (oldI && newI) {
             const memberChanges = [];
@@ -227,27 +236,27 @@ function compareInterfaces(oldInterfaces, newInterfaces) {
                 const oldM = oldI.members.get(memberName);
                 const newM = newI.members.get(memberName);
 
-                 if (!oldM && newM) {
+                if (!oldM && newM) {
                     memberChanges.push(`  - Added member \`${newM.signature}\``);
                 } else if (oldM && !newM) {
                     memberChanges.push(`  - Removed member \`${oldM.name}\``);
                 }
                 // Compare JSDoc-free signatures
                 else if (oldM && newM && oldM.signature !== newM.signature) {
-                    const lineDiffs = Diff.diffLines(oldM.signature, newM.signature, {
+                    const lineDiffs = diffLines(oldM.signature, newM.signature, {
                         newlineIsToken: true,
                         ignoreWhitespace: true, // Ignore whitespace-only changes
                     });
 
-                     // Get formatted diff and inferred context
-                     const { diffBlock, contextName } = formatLineDiffAndInferContext(lineDiffs);
+                    // Get formatted diff and inferred context
+                    const { diffBlock, contextName } = formatLineDiffAndInferContext(lineDiffs);
 
                     // Only report if there are actual diff lines to show
                     if (diffBlock.length > 0) {
                         // Construct label with context if found
-                         const label = `  - Modified member \`${memberName}${contextName ? '.' + contextName : ''}\`:`;
-                         memberChanges.push(label);
-                         memberChanges.push(...diffBlock);
+                        const label = `  - Modified member \`${memberName}${contextName ? '.' + contextName : ''}\`:`;
+                        memberChanges.push(label);
+                        memberChanges.push(...diffBlock);
                     }
                 }
             }
@@ -263,49 +272,55 @@ function compareInterfaces(oldInterfaces, newInterfaces) {
 
 /**
  * Gets the typescript files that have changed (staged or unstaged)
- * compared to BASE_REF within the target directory.
- * @returns {string[]} List of file paths relative to the repo root.
+ * compared to BASE_REF within the target directory using simple-git.
+ * @param {object} git - The simple-git instance.
+ * @returns {Promise<string[]>} List of file paths relative to the repo root.
  */
-function getChangedTsFiles() {
-    // Use porcelain v1 format for simple machine readable output
-    const statusCmd = `git status --porcelain=v1 --untracked-files=all -- "${config.targetDir}"`;
+async function getChangedTsFiles(git) {
+    // Use simple-git status method with options
+    const statusSummary = await git.status([
+        '--porcelain=v1',
+        '--untracked-files=all',
+        '--', // Ensure subsequent arguments are treated as paths
+        config.targetDir,
+    ]);
 
-    let changedOrNewFiles = new Set();
+    const changedOrNewFiles = new Set();
 
-        const statusOutput = execSync(statusCmd, { encoding: 'utf-8' });
+    // Regex to extract file paths starting with target directory and ending with .ts
+    const pathRegex = new RegExp(`${config.targetDir}.*.ts`);
+    for (const file of statusSummary.files) {
+        // Extract the file path part, removing the status flags and whitespace
+        // Example: ' M src/a.ts' -> 'src/a.ts'
+        // Example: '?? src/b.ts' -> 'src/b.ts'
+        const filePath = file.path.match(pathRegex)[0];
 
-    // Parse each line of the git output
-    // e.g.  M src/internal/reference/generated/channels.v3.ts
-    // Assumptions:
-    // - generated files will not have spaces or any special characters in their name
-    // - generation process will produce typescript files
-    // - generation process will completely remove and rebuild the files, so we don't have to handle renames
-    // This logic needs to be more complex if these assumptions are not true in the future
-        statusOutput.split('\n').filter(Boolean).forEach(line => {
-            const filePath = line.substring(3).trim();
-
-        // Only consider files located in the target directory
-        if (filePath.startsWith(config.targetDir)) {
-                changedOrNewFiles.add(filePath);
-            }
-        });
+        // Filter based on target directory and ensure it's a TS file (optional, but good practice)
+        if (filePath) {
+            changedOrNewFiles.add(filePath);
+        }
+    }
 
     return Array.from(changedOrNewFiles);
 }
 
 async function main() {
-    console.log(`Comparing interface changes (pre-stripping JSDoc) between ${config.baseRef} and working tree in ${config.targetDir}...`);
+    console.log(
+        `Comparing interface changes (pre-stripping JSDoc) between ${config.baseRef} and working tree in ${config.targetDir}...`
+    );
     // Set up the markdown summary that will be written to disk.
     let summary = `# Interface Change Summary: ${config.version}\n\n`;
 
     try {
+        const git = simpleGit();
+
         // Create the output directory if it doesn't exist already.
         if (!existsSync(config.outputDir)) {
             mkdirSync(config.outputDir, { recursive: true });
         }
 
         const outputFileName = formatOutputFileName(config);
-        const changedFiles = getChangedTsFiles();
+        const changedFiles = await getChangedTsFiles(git);
 
         // No interface changes this release (maybe it's a bugfix or refactor!)
         // Write an empty summary and exit.
@@ -331,13 +346,21 @@ async function main() {
             console.log(`Processing ${filePath}...`);
 
             // Old file content is read from the git ref.
-            const rawOldContent = getFileContentAtRef(config.baseRef, filePath);
+            const rawOldContent = await getFileContentAtRef(git, config.baseRef, filePath);
             // New file content is read from the working directory.
             let rawNewContent = getFileContentInWorkingDirectory(absoluteFilePath, filePath);
 
             // Parse and compare information about interfaces and their members in the changed content
-            const oldInterfaces = extractInterfaces(projectOld, rawOldContent, `${filePath}.old.virtual.ts`);
-            const newInterfaces = extractInterfaces(projectNew, rawNewContent, `${filePath}.new.virtual.ts`);
+            const oldInterfaces = extractInterfaces(
+                projectOld,
+                rawOldContent,
+                `${filePath}.old.virtual.ts`
+            );
+            const newInterfaces = extractInterfaces(
+                projectNew,
+                rawNewContent,
+                `${filePath}.new.virtual.ts`
+            );
             const fileChanges = compareInterfaces(oldInterfaces, newInterfaces);
 
             if (fileChanges.length) {

--- a/scripts/summarize-changes.js
+++ b/scripts/summarize-changes.js
@@ -1,28 +1,8 @@
-/**
- * This script is used to summarize the changes to the interface definitions in the
- * `src/internal/reference/generated` directory between the current HEAD and the
- * previous commit.
- *
- * It should be run from the root of the repo immediately after rebuilding the
- * generated files - this is handled by the `build:clean` script already.
- *
- * It will output a markdown file to `docs/changelog` with the following format:
- *
- * # Interface Change Summary: 1.0.0
- *
- * ## src/internal/reference/generated/channels.v3.ts
- *
- * - **Added Interface:** \`ChannelNode\`
- * - **Removed Interface:** \`ChannelNode\`
- *
- */
-// TECH DEBT: This is a naive approach that uses regex to remove JSDocs and find parents properties.
-// It can probably be improved by leaning more on ts-morph to parse the AST.
 import { diffLines } from 'diff';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { resolve } from 'path';
 import { GitError, simpleGit } from 'simple-git';
-import { Project, SyntaxKind } from 'ts-morph';
+import { Project, SyntaxKind, Node as TsNode } from 'ts-morph';
 
 const packageJson = JSON.parse(readFileSync('package.json', 'utf-8'));
 
@@ -33,242 +13,112 @@ const config = {
     outputDir: `docs/changelog`,
 };
 
-function formatOutputFileName(config) {
-    return `${config.outputDir}/${config.version}.md`;
-}
-
 /**
- * Gets the content of a file at a specific Git reference.
+ * Summarize the changes to the interface definitions in the
+ * `src/internal/reference/generated` directory between the current HEAD and the
+ * previous commit.
  *
- * @param {object} git - The simple-git instance.
- * @param {string} gitRef - The git reference to check.
- * @param {string} filePath - Path relative to repo root
- * @returns {Promise<string>} The file content or an empty string if the file doesn't exist at that ref.
+ * The script should be run from the root of the repo immediately after rebuilding the
+ * generated files (this is handled by the `build:clean` script already).
+ *
+ * It will output a markdown file to `docs/changelog` with the following format:
+ *
+ * # Interface Change Summary: 1.0.0
+ *
+ * ## `customers.v3.ts`
+ *
+ * operations.getMetafieldsCustomerId.responses:
+ * ```diff
+ * -             readonly 200: components["responses"]["MetafieldCollectionResponse"];
+ * +             readonly 200: {
+ * ```
+ *
  */
-async function getFileContentAtRef(git, gitRef, filePath) {
-    return git.show(`${gitRef}:${filePath}`).catch(error => {
-        // If the error is that the file didn't exist for the given ref, return an empty string.
-        // This means the file is new and we're happy to continue as though it's an empty file.
-        if (
-            error instanceof GitError &&
-            [
-                `exists on disk, but not in '${gitRef}'`,
-                `does not exist in '${gitRef}'`,
-                `Path '${filePath}' does not exist in '${gitRef}'`,
-            ].some(error.stderr.includes)
-        ) {
-            return '';
+async function main() {
+    console.log(
+        `Comparing interface changes (pre-stripping JSDoc) between ${config.baseRef} and working tree in ${config.targetDir}...\n`
+    );
+    // Title for the markdown summary that will be written to disk.
+    let summary = `# Interface Change Summary: ${config.version}\n\n`;
+
+    try {
+        // Create a simple-git instance to get information about the previous file state.
+        const git = simpleGit();
+
+        // Create the output directory if it doesn't exist already.
+        if (!existsSync(config.outputDir)) {
+            mkdirSync(config.outputDir, { recursive: true });
         }
 
-        // Some other error, rethrow it.
-        throw error;
-    });
-}
+        const outputFileName = `${config.outputDir}/${config.version}.md`;
+        const changedFiles = await getChangedTsFiles(git);
 
-/**
- * Gets the content of a file in the working directory.
- * @param {string} absoluteFilePath - The absolute path to the file.
- * @param {string} filePath - The path to the file relative to the repo root.
- * @returns {string} The file content or an empty string if the file doesn't exist.
- */
-function getFileContentInWorkingDirectory(absoluteFilePath, filePath) {
-    if (existsSync(absoluteFilePath)) {
-        try {
-            return readFileSync(absoluteFilePath, 'utf-8');
-        } catch (readError) {
-            console.warn(`Warning: Could not read file ${filePath} from disk. Error: ${readError}`);
+        // No interface changes this release (maybe it's a bugfix or refactor!)
+        // Write an empty summary and exit.
+        if (!changedFiles.length) {
+            summary += `No interface changes in ${config.targetDir}.\n`;
+            console.log(`No interface changes in ${config.targetDir}.`);
+            writeFileSync(outputFileName, summary);
+            return;
         }
-    } else {
+
         console.log(
-            `File ${filePath} does not exist in working directory (likely deleted or renamed away).`
+            `Found changed/new files in ${config.targetDir}:\n  - ${changedFiles.join('\n  - ')}\n`
         );
-    }
-    return '';
-}
 
-/**
- * Extracts exported interface details from TypeScript source code.
- * Assumes JSDoc has already been stripped from the input sourceCode.
- * @param {Project} project - The ts-morph project instance.
- * @param {string} sourceCode - The TypeScript source code content (JSDoc removed).
- * @param {string} virtualFilePath - A unique virtual path for ts-morph.
- * @returns {Map<string, {name: string, members: Map<string, {name: string, signature: string}>}>}
- */
-function extractInterfaces(project, sourceCode, virtualFilePath) {
-    const interfaces = new Map();
+        // Initialise ts-morph projects for parsing changed content
+        const projectOld = new Project({ useInMemoryFileSystem: true });
+        const projectNew = new Project({ useInMemoryFileSystem: true });
 
-    // If there is no source code (e.g., the file was deleted), return an empty map.
-    if (!sourceCode) {
-        return interfaces;
-    }
+        // For each file that has changed relative to the base git ref
+        // Group changes by the path to the changed property and add
+        // markdown diff blocks to the summary
+        for (const filePath of changedFiles) {
+            console.log(`Processing ${filePath}...`);
 
-    const sourceFile = project.createSourceFile(virtualFilePath, sourceCode, {
-        overwrite: true,
-    });
+            const { oldSource, newSource } = await prepareSourceFiles(
+                git,
+                filePath,
+                projectOld,
+                projectNew
+            );
 
-    // Remove all JSDoc blocks from the source file.
-    sourceFile.getDescendantsOfKind(SyntaxKind.JSDoc).forEach(jsDoc => jsDoc.remove());
-
-    sourceFile.getInterfaces().forEach(interfaceDeclaration => {
-        // Only extract exported interfaces as they represent the public API
-        if (interfaceDeclaration.isExported()) {
-            const interfaceName = interfaceDeclaration.getName();
-            const membersMap = new Map();
-            interfaceDeclaration.getMembers().forEach(member => {
-                const memberName = member.getName();
-                // Get text directly from the node in the JSDoc-stripped AST
-                const signature = member.getText().trim();
-
-                if (memberName && signature) {
-                    membersMap.set(memberName, { name: memberName, signature: signature });
-                }
+            const diff = diffLines(oldSource.getFullText(), newSource.getFullText(), {
+                newlineIsToken: true,
+                ignoreWhitespace: true,
             });
-            interfaces.set(interfaceName, { name: interfaceName, members: membersMap });
-        }
-    });
 
-    return interfaces;
-}
+            let changeGroups = groupChangesByPropertyPath(diff, newSource, oldSource);
 
-/**
- * Formats the diff output for markdown and tries to infer the nested context name.
- * @param {object[]} lineDiffs - Array of change objects from diffLines.
- * @returns {{diffBlock: string[], contextName: string | null}} - Formatted diff lines and the inferred context name (e.g., 'CategoryNode').
- */
-function formatLineDiffAndInferContext(lineDiffs) {
-    const outputLines = [];
-    let lastPotentialContextName = null;
-    let contextNameForChange = null;
-    let hasVisibleChanges = false;
-    // Regex to capture a potential property name before an opening brace, possibly readonly.
-    // Captures the identifier (\w+). Increased robustness for whitespace.
-    const contextNameRegex = /^\s*(?:readonly\s+)?(\w+)\s*:\s*\{/;
+            if (changeGroups.size) {
+                console.log(
+                    `  - Summarizing ${changeGroups.size} group${changeGroups.size === 1 ? '' : 's'} of changes`
+                );
 
-    // Check if we have any actual changes to report, return early if not
-    const changeParts = lineDiffs.filter(part => part.added || part.removed);
-    if (!changeParts.length) {
-        return { diffBlock: [], contextName: null };
-    }
+                // Remove unnecessary prefixes from the file path for readability
+                // e.g. src/internal/reference/generated/channels.v3.ts --> channels.v3.ts
+                const displayPath = filePath.replace(new RegExp(`^${config.targetDir}/`), '');
 
-    // Start writing the diff block - e.g.
-    // ```diff
-    // - ...
-    // + ...
-    // ```
-    outputLines.push('    ```diff');
-    let changeBlockActive = false;
-
-    lineDiffs.forEach(part => {
-        const lines = part.value.split('\n');
-
-        // The logic here is a bit complex - the purpose is to find the 'context' for a change,
-        // which is usually the name of the interface or property that the changed member belongs to.
-        if (!part.added && !part.removed) {
-            // Look for context in lines preceding a change block
-            lines.forEach(line => {
-                const match = line.match(contextNameRegex);
-                if (match && !changeBlockActive) {
-                    // Only update context if we are not inside a change block
-                    lastPotentialContextName = match[1];
+                // Add an entry for this file to the summary.
+                summary += `## \`${displayPath}\`\n\n`;
+                for (const [path, changes] of changeGroups.entries()) {
+                    summary += changeGroupToDiffBlock(path, changes).join('\n') + '\n\n';
                 }
-            });
-            changeBlockActive = false; // Reset flag when entering context block
-        } else {
-            // This part has additions or removals
-            hasVisibleChanges = true;
-            changeBlockActive = true; // Set flag when inside a change block
-            if (contextNameForChange === null && lastPotentialContextName !== null) {
-                // Capture the last known context name *before* the first change line
-                contextNameForChange = lastPotentialContextName;
-            }
-
-            const prefix = part.added ? '+ ' : '- ';
-            lines.forEach((line, idx) => {
-                // Avoid adding trailing newline as a separate diff line if it exists
-                if (idx === lines.length - 1 && line === '') return;
-                outputLines.push(`    ${prefix}${line}`);
-            });
-        }
-    });
-
-    // Close the diff block
-    outputLines.push('    ```');
-
-    // Ensure we only return a diff block if there were actual visible changes
-    return {
-        diffBlock: hasVisibleChanges ? outputLines : [],
-        contextName: contextNameForChange, // Return the context identified before the first +/- line
-    };
-}
-
-/**
- * Compares two sets of interface definitions and returns a summary string array.
- * Operates on signatures assumed to be JSDoc-free due to pre-processing.
- * @param {Map<string, {name: string, members: Map<string, {name: string, signature: string}>}>} oldInterfaces
- * @param {Map<string, {name: string, members: Map<string, {name: string, signature: string}>}>} newInterfaces
- * @returns {string[]}
- */
-function compareInterfaces(oldInterfaces, newInterfaces) {
-    const changes = [];
-    const allNames = new Set([...oldInterfaces.keys(), ...newInterfaces.keys()]);
-
-    for (const name of allNames) {
-        const oldI = oldInterfaces.get(name);
-        const newI = newInterfaces.get(name);
-
-        // In the unlikely event that an entire interface was added or removed,
-        // Handle it here.
-        if (!oldI) {
-            changes.push(`- **Added Interface:** \`${name}\``);
-            continue;
-        }
-
-        if (!newI) {
-            changes.push(`- **Removed Interface:** \`${name}\``);
-            continue;
-        }
-
-        if (oldI && newI) {
-            const memberChanges = [];
-            const allMemberNames = new Set([...oldI.members.keys(), ...newI.members.keys()]);
-
-            for (const memberName of allMemberNames) {
-                const oldM = oldI.members.get(memberName);
-                const newM = newI.members.get(memberName);
-
-                if (!oldM && newM) {
-                    memberChanges.push(`  - Added member \`${newM.signature}\``);
-                } else if (oldM && !newM) {
-                    memberChanges.push(`  - Removed member \`${oldM.name}\``);
-                }
-                // Compare JSDoc-free signatures
-                else if (oldM && newM && oldM.signature !== newM.signature) {
-                    const lineDiffs = diffLines(oldM.signature, newM.signature, {
-                        newlineIsToken: true,
-                        ignoreWhitespace: true, // Ignore whitespace-only changes
-                    });
-
-                    // Get formatted diff and inferred context
-                    const { diffBlock, contextName } = formatLineDiffAndInferContext(lineDiffs);
-
-                    // Only report if there are actual diff lines to show
-                    if (diffBlock.length > 0) {
-                        // Construct label with context if found
-                        const label = `  - Modified member \`${memberName}${contextName ? '.' + contextName : ''}\`:`;
-                        memberChanges.push(label);
-                        memberChanges.push(...diffBlock);
-                    }
-                }
-            }
-
-            if (memberChanges.length > 0) {
-                changes.push(`- **Modified Interface:** \`${name}\``);
-                changes.push(...memberChanges);
+            } else {
+                console.log(`  - No interface changes found`);
             }
         }
+
+        // Write the complete summary to disk.
+        writeFileSync(outputFileName, summary);
+        console.log(`\nSummary written to ${outputFileName}`);
+    } catch (error) {
+        console.error('\nError generating interface change summary:', error);
+        process.exit(1);
     }
-    return changes;
 }
+
+main();
 
 /**
  * Gets the typescript files that have changed (staged or unstaged)
@@ -304,83 +154,162 @@ async function getChangedTsFiles(git) {
     return Array.from(changedOrNewFiles);
 }
 
-async function main() {
-    console.log(
-        `Comparing interface changes (pre-stripping JSDoc) between ${config.baseRef} and working tree in ${config.targetDir}...`
-    );
-    // Set up the markdown summary that will be written to disk.
-    let summary = `# Interface Change Summary: ${config.version}\n\n`;
-
-    try {
-        const git = simpleGit();
-
-        // Create the output directory if it doesn't exist already.
-        if (!existsSync(config.outputDir)) {
-            mkdirSync(config.outputDir, { recursive: true });
+/**
+ * Gets the content of a file at a specific Git reference.
+ *
+ * @param {object} git - The simple-git instance.
+ * @param {string} gitRef - The git reference to check.
+ * @param {string} filePath - Path relative to repo root
+ * @returns {Promise<string>} The file content or an empty string if the file doesn't exist at that ref.
+ */
+async function getFileContentAtRef(git, gitRef, filePath) {
+    return git.show(`${gitRef}:${filePath}`).catch(error => {
+        // If the error is that the file didn't exist for the given ref, return an empty string.
+        // This means the file is new and we're happy to continue as though it's an empty file.
+        if (
+            error instanceof GitError &&
+            [
+                `exists on disk, but not in '${gitRef}'`,
+                `does not exist in '${gitRef}'`,
+                `Path '${filePath}' does not exist in '${gitRef}'`,
+            ].some(error.stderr.includes)
+        ) {
+            return '';
         }
 
-        const outputFileName = formatOutputFileName(config);
-        const changedFiles = await getChangedTsFiles(git);
-
-        // No interface changes this release (maybe it's a bugfix or refactor!)
-        // Write an empty summary and exit.
-        if (!changedFiles.length) {
-            summary += `No interface changes in ${config.targetDir}.\n`;
-            console.log(`No interface changes in ${config.targetDir}.`);
-            writeFileSync(outputFileName, summary);
-            return;
-        }
-
-        console.log(`Found changed/new files in ${config.targetDir}:\n${changedFiles.join('\n')}`);
-
-        // Initialise ts-morph projects for parsing changed content
-        const projectOld = new Project({ useInMemoryFileSystem: true });
-        const projectNew = new Project({ useInMemoryFileSystem: true });
-
-        // For each file that has changed relative to the base git ref:
-        // - Read the old and new content, preprocess to remove JSDoc
-        // - Parse the old and new content into TypeScript interface information
-        // - Compare the interfaces and generate a summary of changed interfaces and members
-        for (const filePath of changedFiles) {
-            const absoluteFilePath = resolve(filePath);
-            console.log(`Processing ${filePath}...`);
-
-            // Old file content is read from the git ref.
-            const rawOldContent = await getFileContentAtRef(git, config.baseRef, filePath);
-            // New file content is read from the working directory.
-            let rawNewContent = getFileContentInWorkingDirectory(absoluteFilePath, filePath);
-
-            // Parse and compare information about interfaces and their members in the changed content
-            const oldInterfaces = extractInterfaces(
-                projectOld,
-                rawOldContent,
-                `${filePath}.old.virtual.ts`
-            );
-            const newInterfaces = extractInterfaces(
-                projectNew,
-                rawNewContent,
-                `${filePath}.new.virtual.ts`
-            );
-            const fileChanges = compareInterfaces(oldInterfaces, newInterfaces);
-
-            if (fileChanges.length) {
-                // Remove unnecessary prefixes from the file path for readability
-                // e.g. src/internal/reference/generated/channels.v3.ts --> channels.v3.ts
-                const displayPath = filePath.replace(new RegExp(`^${config.targetDir}/`), '');
-
-                // Add an entry for this file to the summary.
-                summary += `## \`${displayPath}\`\n\n`;
-                summary += fileChanges.join('\n') + '\n\n';
-            }
-        }
-
-        // Write the complete summary to disk.
-        writeFileSync(outputFileName, summary);
-        console.log(`Summary written to ${outputFileName}`);
-    } catch (error) {
-        console.error('Error generating interface change summary:', error);
-        process.exit(1);
-    }
+        // Some other error, rethrow it.
+        throw error;
+    });
 }
 
-main();
+/**
+ * Gets the content of a file in the working directory.
+ * @param {string} filePath - The path to the file relative to the repo root.
+ * @returns {string} The file content or an empty string if the file doesn't exist.
+ */
+function getFileContentInWorkingDirectory(filePath) {
+    const absoluteFilePath = resolve(filePath);
+    if (existsSync(absoluteFilePath)) {
+        try {
+            return readFileSync(absoluteFilePath, 'utf-8');
+        } catch (readError) {
+            console.warn(`Warning: Could not read file ${filePath} from disk. Error: ${readError}`);
+        }
+    } else {
+        console.log(
+            `File ${filePath} does not exist in working directory (likely deleted or renamed away).`
+        );
+    }
+
+    // Assume missing files have been deleted, treat as empty documents
+    return '';
+}
+
+/**
+ * Prepares virtual source files for parsing.
+ * @param {object} git - The simple-git instance.
+ * @param {string} filePath - The path to the file relative to the repo root.
+ * @param {Project} projectOld - The ts-morph project instance for the old file.
+ * @param {Project} projectNew - The ts-morph project instance for the new file.
+ */
+async function prepareSourceFiles(git, filePath, projectOld, projectNew) {
+    // Old file content is read from the git ref.
+    const rawOldContent = await getFileContentAtRef(git, config.baseRef, filePath);
+
+    // New file content is read from the working directory.
+    let rawNewContent = getFileContentInWorkingDirectory(filePath);
+
+    // Initialise virtual source files for parsing
+    const oldSource = projectOld.createSourceFile(`${filePath}.old.virtual.ts`, rawOldContent, {
+        overwrite: true,
+    });
+
+    const newSource = projectNew.createSourceFile(`${filePath}.new.virtual.ts`, rawNewContent, {
+        overwrite: true,
+    });
+
+    // Remove all JSDoc blocks from the source files.
+    oldSource.getDescendantsOfKind(SyntaxKind.JSDoc).forEach(jsDoc => jsDoc.remove());
+    newSource.getDescendantsOfKind(SyntaxKind.JSDoc).forEach(jsDoc => jsDoc.remove());
+
+    return { oldSource, newSource };
+}
+
+function getDotPathToPosition(source, position) {
+    const node = source.getDescendantAtPos(position);
+    const namedParent = node?.getFirstAncestor(n => TsNode.hasName(n));
+    return namedParent
+        ?.getAncestors()
+        .reverse()
+        .map(n => (TsNode.hasName(n) ? n.getName() : ''))
+        .filter(n => n !== '')
+        .join('.');
+}
+function groupChangesByPropertyPath(diff, newSource, oldSource) {
+    let position = { added: 0, removed: 0 };
+    let lineChanges = new Map();
+    let path = '';
+
+    // Small helper function for grouping changes in the map
+    const recordChange = (path, change) => {
+        if (!lineChanges.has(path)) {
+            lineChanges.set(path, []);
+        }
+        lineChanges.get(path).push(change);
+    };
+
+    for (const change of diff) {
+        // For additions and removals we work out the path to the first token,
+        // then record the change under that path. The character position is used
+        // to find the change in the Typescript source, and the position of additions/removals
+        // correlates to the new/old typescript source respectively
+        if (change.added) {
+            path = getDotPathToPosition(newSource, position.added);
+            recordChange(path, change);
+            position.added += change.value.length;
+            continue;
+        }
+
+        if (change.removed) {
+            path = getDotPathToPosition(oldSource, position.removed);
+            recordChange(path, change);
+            position.removed += change.value.length;
+            continue;
+        }
+
+        // If there's a single line that hasn't changed it's often just a newline
+        // or bracket between two connected changes. Group it with the previous
+        // change as this leads to clearer output
+        if (change.value.split('\n').length === 1) {
+            recordChange(path, change);
+        }
+
+        position.added += change.value.length;
+        position.removed += change.value.length;
+    }
+    return lineChanges;
+}
+
+/**
+ * Takes a group of changes at a property path and retuns an array
+ * of lines for a markdown diff block.
+ * @param {string} path - The dot path to the line change.
+ * @param {object[]} changes - The change object.
+ * @returns {string[]} The formatted line change.
+ */
+function changeGroupToDiffBlock(path, changes) {
+    const terminatingNewLineRegex = /\n$/;
+    const lines = changes
+        .map(change =>
+            change.value
+                .replace(terminatingNewLineRegex, '')
+                .split(`\n`)
+                .map(line => {
+                    const prefix = change.added ? '+' : change.removed ? '-' : ' ';
+                    return `${prefix} ${line}`;
+                })
+                .join(`\n`)
+        )
+        .join(`\n`);
+    return [`${path}:`, '```diff', lines, '```'];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "extends": "./tsconfig.base.json",
     "include": ["src"],
-    "exclude": ["node_modules", "dist"]
+    "exclude": ["node_modules", "dist", "scripts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,6 +11,7 @@ __metadata:
   dependencies:
     "@aligent/ts-code-standards": "npm:^4.0.0"
     "@types/node": "npm:^22.13.14"
+    diff: "npm:^8.0.0-beta"
     eslint: "npm:^9.25.1"
     form-data: "npm:^4.0.2"
     node-fetch: "npm:^3.3.2"
@@ -1132,6 +1133,13 @@ __metadata:
   version: 29.6.3
   resolution: "diff-sequences@npm:29.6.3"
   checksum: 10c0/32e27ac7dbffdf2fb0eb5a84efd98a9ad084fbabd5ac9abb8757c6770d5320d2acd172830b28c4add29bb873d59420601dfc805ac4064330ce59b1adfd0593b2
+  languageName: node
+  linkType: hard
+
+"diff@npm:^8.0.0-beta":
+  version: 8.0.0-beta
+  resolution: "diff@npm:8.0.0-beta"
+  checksum: 10c0/6c00c9decaecaa389ede271efa58b35c4eb334f4ba82e10bfa3ed8d0077ad483dbf73641fb7451dd12001b19bcce764ea388333952799bdfb4ff233784e557cc
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,7 @@ __metadata:
     prettier: "npm:^3.5.3"
     query-string: "npm:^9.1.1"
     rimraf: "npm:^6.0.1"
+    simple-git: "npm:^3.27.0"
     temp-dir: "npm:^3.0.0"
     ts-morph: "npm:^25.0.1"
     tsd: "npm:^0.32.0"
@@ -229,6 +230,22 @@ __metadata:
   dependencies:
     "@sinclair/typebox": "npm:^0.27.8"
   checksum: 10c0/b329e89cd5f20b9278ae1233df74016ebf7b385e0d14b9f4c1ad18d096c4c19d1e687aa113a9c976b16ec07f021ae53dea811fb8c1248a50ac34fbe009fdf6be
+  languageName: node
+  linkType: hard
+
+"@kwsites/file-exists@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/file-exists@npm:1.1.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+  checksum: 10c0/39e693239a72ccd8408bb618a0200e4a8d61682057ca7ae2c87668d7e69196e8d7e2c9cde73db6b23b3b0230169a15e5f1bfe086539f4be43e767b2db68e8ee4
+  languageName: node
+  linkType: hard
+
+"@kwsites/promise-deferred@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@kwsites/promise-deferred@npm:1.1.1"
+  checksum: 10c0/ef1ad3f1f50991e3bed352b175986d8b4bc684521698514a2ed63c1d1fc9848843da4f2bc2df961c9b148c94e1c34bf33f0da8a90ba2234e452481f2cc9937b1
   languageName: node
   linkType: hard
 
@@ -1057,7 +1074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -3878,6 +3895,17 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10c0/41602dce540e46d599edba9d9860193398d135f7ff72cab629db5171516cfae628d21e7bfccde1bbfdf11c48726bc2a6d1a8fb8701125852fbfda7cf19c6aa83
+  languageName: node
+  linkType: hard
+
+"simple-git@npm:^3.27.0":
+  version: 3.27.0
+  resolution: "simple-git@npm:3.27.0"
+  dependencies:
+    "@kwsites/file-exists": "npm:^1.1.1"
+    "@kwsites/promise-deferred": "npm:^1.1.1"
+    debug: "npm:^4.3.5"
+  checksum: 10c0/ef56cabea585377d3e0ca30e4e93447f465d91f23eaf751693cc31f366b5f7636facf52ad5bcd598bfdf295fa60732e7a394303d378995b52e2d221d92e5f9f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
---

**Description of the proposed changes**

Adds a command `yarn build:summarize-changes` which:

- Reads changes to the files in `src/internal/reference/generated` via git
- Extracts changes to actual interfaces (not doc blocks)
- Writes a file to `docs/changelog/${version}.md` with the changes formatted as diffs

**Screenshots (if applicable)**

Example from upcoming release:
![image](https://github.com/user-attachments/assets/680c2d74-6621-4b14-921d-aa48656bf691)

**Other solutions considered (if any)**

This is a quick solution mostly generated by AI. I suspect proper use of `ts-morph` and `diff` libraries would result in a better implementation, but this isn't runtime code and the output is good enough for now.

**Notes to reviewers**

🛈 When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback
